### PR TITLE
Modifications suite soutenance

### DIFF
--- a/src/contexts/DataContext/index.js
+++ b/src/contexts/DataContext/index.js
@@ -19,6 +19,18 @@ export const api = {
 export const DataProvider = ({ children }) => {
   const [error, setError] = useState(null)
   const [data, setData] = useState(null)
+
+  // Créer un nouveau tableau ordonné eventsByDateDesc à partir de data.events dans lequel les événements sont triés par date du plus récent au plus ancien.
+  const eventsByDateDesc =
+    data && data.events
+      ? [...data.events].sort((evtA, evtB) =>
+          new Date(evtA.date) < new Date(evtB.date) ? 1 : -1
+        )
+      : []
+
+  // Définir "last" pour récupérer les données de l'événement le plus récent (le premier dans le tableau ordonné eventsByDateDesc). Si le tableau est vide, la valeur de last est "null". Ceci corrige le bug d'affichage de la card dans le Footer en affichant bien la dernière prestation (c'est à dire la plus récente, et non la dernière entrée du tableau de données).
+  const last = eventsByDateDesc.length > 0 ? eventsByDateDesc[0] : null
+
   const getData = useCallback(async () => {
     try {
       setData(await api.loadData())
@@ -38,6 +50,7 @@ export const DataProvider = ({ children }) => {
       value={{
         data,
         error,
+        last,
       }}
     >
       {children}

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -13,9 +13,7 @@ import Modal from '../../containers/Modal'
 import { useData } from '../../contexts/DataContext'
 
 const Page = () => {
-  const { data } = useData()
-  // Définir "last" pour récupérer les données de l'événement le plus récent (le dernier). Si le tableau est vide, la valeur de last est "null". Ceci corrige le bug d'affichage de la card dans le Footer.
-  const last = data ? data.events[data.events.length - 1] : null
+  const { last } = useData()
 
   return (
     <>


### PR DESCRIPTION
 Déclaration de "last" directement dans DataContext pour récupérer la dernière prestation (la plus récente en terme de date, et non la dernière entrée du tableau de données) et l'afficher dans EventCard du Footer.